### PR TITLE
Bring in environment variable templating from Jason's fork.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "fable-settings",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "A simple, tolerant configuration chain.",
   "main": "source/Fable-Settings.js",
   "scripts": {
     "start": "node source/Fable-Settings.js",
-    "coverage": "./node_modules/nyc/bin/nyc.js --reporter=lcov --reporter=text-lcov ./node_modules/mocha/bin/_mocha -- -u tdd -R spec",
+    "coverage": "nyc npm run test --reporter=lcov",
     "test": "./node_modules/mocha/bin/_mocha -u tdd -R spec"
   },
   "repository": {
@@ -37,5 +37,7 @@
     "vinyl-buffer": "^1.0.1",
     "vinyl-source-stream": "^2.0.0"
   },
-  "dependencies": {}
+  "dependencies": {
+    "match-all": "^1.2.6"
+  }
 }

--- a/test/ExampleSettings.json
+++ b/test/ExampleSettings.json
@@ -15,6 +15,10 @@
 
 	"MongoDBURL":"mongodb://127.0.0.1/Fable",
 
+	"Environment": "${NOT_DEFAULT|default}-${USE_DEFAULT|default}",
+
+	"EnvArray": [ "${NOT_DEFAULT|default}", "${USE_DEFAULT|default}" ],
+
 	"MySQL":
 		{
 			"Server": "127.0.0.1",

--- a/test/Fable-Settings_tests.js
+++ b/test/Fable-Settings_tests.js
@@ -168,6 +168,55 @@ suite
 							.to.equal('ApplicationNameHere');
 					}
 				);
+				test
+				(
+					'resolve environment variables',
+					function()
+					{
+						process.env['NOT_DEFAULT'] = 'found_value';
+
+						const tmpFableSettings = require('../source/Fable-Settings.js').new(
+						{
+							DefaultConfigFile: `${__dirname}/DefaultExampleSettings.json`,
+							ConfigFile: `${__dirname}/ExampleSettings.json`
+						});
+						Expect(tmpFableSettings).to.have.a.property('settings')
+							.that.is.a('object');
+						Expect(tmpFableSettings.settings).to.have.a.property('Environment')
+							.that.is.a('string');
+						Expect(tmpFableSettings.settings.Environment)
+							.to.equal('found_value-default');
+						Expect(tmpFableSettings.settings).to.have.a.property('EnvArray')
+							.that.is.an('array');
+						Expect(tmpFableSettings.settings.EnvArray)
+							.to.deep.equal(['found_value', 'default']);
+					}
+				);
+				test
+				(
+					'ignores environment variables if disabled',
+					function()
+					{
+						process.env['NOT_DEFAULT'] = 'found_value';
+
+						const tmpFableSettings = require('../source/Fable-Settings.js').new(
+						{
+							NoEnvReplacement: true,
+							DefaultConfigFile: `${__dirname}/DefaultExampleSettings.json`,
+							ConfigFile: `${__dirname}/ExampleSettings.json`
+						});
+						Expect(tmpFableSettings).to.have.a.property('settings')
+							.that.is.a('object');
+						Expect(tmpFableSettings.settings).to.have.a.property('Environment')
+							.that.is.a('string');
+						Expect(tmpFableSettings.settings.Environment)
+							.to.equal('${NOT_DEFAULT|default}-${USE_DEFAULT|default}');
+						Expect(tmpFableSettings.settings).to.have.a.property('EnvArray')
+							.that.is.an('array');
+						Expect(tmpFableSettings.settings.EnvArray)
+							.to.deep.equal(['${NOT_DEFAULT|default}', '${USE_DEFAULT|default}']);
+					}
+				);
 			}
 		);
 	}


### PR DESCRIPTION
* I couldn't bring it over as-is as it was against 1.x, but left more or less alone.
* I added a test for arrays of strings.
* I added a setting to turn off environment variable templating (on by default).
* I fixed a bug where input or intermediate settings objects could be mutated which was breaking the tests.
* I simplified the test invocation to DRY since we already had a test target.