### PR TITLE
 Merge settings subobjects rather than overwriting them.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fable-settings",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "A simple, tolerant configuration chain.",
   "main": "source/Fable-Settings.js",
   "scripts": {

--- a/test/DefaultExampleSettings.json
+++ b/test/DefaultExampleSettings.json
@@ -2,5 +2,10 @@
 	"Product": "BestProductEver - DEFAULT",
 	"ProductVersion": "0.0.0",
 
-	"TestValue": "NOT_OVERIDDEN"
+	"TestValue": "NOT_OVERIDDEN",
+	"ComplexMerge":
+	{
+		"DefaultKey": "DefaultValue",
+		"OverriddenKey": "IrrelevantValue"
+	}
 }

--- a/test/ExampleSettings.json
+++ b/test/ExampleSettings.json
@@ -29,5 +29,10 @@
 			"ConnectionPoolLimit": 20
 		},
 
-	"LogStreams": [{"streamtype":"process.stdout", "level":"trace"}]
+	"LogStreams": [{"streamtype":"process.stdout", "level":"trace"}],
+	"ComplexMerge":
+	{
+		"NewKey": "NewValue",
+		"OverriddenKey": "ImportantValue"
+	}
 }

--- a/test/Fable-Settings_tests.js
+++ b/test/Fable-Settings_tests.js
@@ -94,7 +94,19 @@ suite
 							.to.equal('0.0.0');
 
 						// Test the object fill method.
-						tmpFableSettings.fill({Product:'DontOverwriteMe',SomeFancySetting:'CreateMe'});
+						tmpFableSettings.fill({ ComplexMerge: { DefaultKey: 'DefaultValue' } });
+						const toFill =
+						{
+							Product:'DontOverwriteMe',
+							SomeFancySetting:'CreateMe',
+							ComplexMerge:
+							{
+								DefaultKey: 'IgnoredValue',
+								NewKey: 'NewValue',
+							},
+						};
+						const fillParameter = JSON.parse(JSON.stringify(toFill));
+						tmpFableSettings.fill(fillParameter);
 						// Fill should have ignored overwriting existing settings
 						Expect(tmpFableSettings.settings.Product)
 							.to.equal('NewSettingsObject');
@@ -103,7 +115,13 @@ suite
 							.to.equal('CreateMe');
 						// Exercise filling without a good value
 						tmpFableSettings.fill();
-							console.log('1')
+						Expect(tmpFableSettings.settings.ComplexMerge).to.deep.equal(
+						{
+							DefaultKey: 'DefaultValue',
+							NewKey: 'NewValue',
+						});
+						// ensure we didn't mutate the fill input
+						Expect(toFill).to.deep.equal(fillParameter);
 					}
 				);
 				test
@@ -118,6 +136,13 @@ suite
 							.that.is.a('string');
 						Expect(tmpFableSettings.settings.Product)
 							.to.equal('BestProductEver - DEFAULT');
+						Expect(tmpFableSettings.settings).to.have.a.property('ComplexMerge')
+							.that.is.an('object');
+						Expect(tmpFableSettings.settings.ComplexMerge).to.deep.equal(
+						{
+							DefaultKey: 'DefaultValue',
+							OverriddenKey: 'IrrelevantValue',
+						});
 					}
 				);
 				test
@@ -152,6 +177,14 @@ suite
 							.to.equal('BestProductEver');
 						Expect(tmpFableSettings.settings.TestValue)
 							.to.equal('NOT_OVERIDDEN');
+						Expect(tmpFableSettings.settings).to.have.a.property('ComplexMerge')
+							.that.is.an('object');
+						Expect(tmpFableSettings.settings.ComplexMerge).to.deep.equal(
+						{
+							DefaultKey: 'DefaultValue',
+							OverriddenKey: 'ImportantValue',
+							NewKey: 'NewValue',
+						});
 					}
 				);
 				test
@@ -190,6 +223,14 @@ suite
 							.that.is.an('array');
 						Expect(tmpFableSettings.settings.EnvArray)
 							.to.deep.equal(['found_value', 'default']);
+						Expect(tmpFableSettings.settings).to.have.a.property('ComplexMerge')
+							.that.is.an('object');
+						Expect(tmpFableSettings.settings.ComplexMerge).to.deep.equal(
+						{
+							DefaultKey: 'DefaultValue',
+							OverriddenKey: 'ImportantValue',
+							NewKey: 'NewValue',
+						});
 					}
 				);
 				test
@@ -215,6 +256,14 @@ suite
 							.that.is.an('array');
 						Expect(tmpFableSettings.settings.EnvArray)
 							.to.deep.equal(['${NOT_DEFAULT|default}', '${USE_DEFAULT|default}']);
+						Expect(tmpFableSettings.settings).to.have.a.property('ComplexMerge')
+							.that.is.an('object');
+						Expect(tmpFableSettings.settings.ComplexMerge).to.deep.equal(
+						{
+							DefaultKey: 'DefaultValue',
+							OverriddenKey: 'ImportantValue',
+							NewKey: 'NewValue',
+						});
 					}
 				);
 			}


### PR DESCRIPTION
* Updated test config and test cases. They are failing at this point.
* Changes:
  * I wrote a simple merge method by hand to avoid adding a new dependency, as discussed.
  * I fixed a bug where we would mutate the input in `fill`. Code now matches `merge`.
  * All test cases now pass.
* Bumped package version as a separate commit.

Testing done:
* `npm run coverage`