### PR TITLE
Allow different configuration layers to update NoEnvReplacement. Check before doing initial merge.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fable-settings",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "A simple, tolerant configuration chain.",
   "main": "source/Fable-Settings.js",
   "scripts": {

--- a/source/Fable-Settings.js
+++ b/source/Fable-Settings.js
@@ -21,13 +21,13 @@ class FableSettings
 {
 	constructor(pFableSettings)
 	{
+		// set straight away so anything that uses it respects the initial setting
+		this._configureEnvTemplating(pFableSettings);
+
 		this.default = this.buildDefaultSettings();
 
 		// Construct a new settings object
 		let tmpSettings = this.merge(pFableSettings, this.buildDefaultSettings());
-
-		// default environment variable templating to on
-		this._PerformEnvTemplating = !tmpSettings || tmpSettings.NoEnvReplacement !== true;
 
 		// The base settings object (what they were on initialization, before other actors have altered them)
 		this.base = JSON.parse(JSON.stringify(tmpSettings));
@@ -73,6 +73,12 @@ class FableSettings
 		return JSON.parse(JSON.stringify(require('./Fable-Settings-Default')));
 	}
 
+	// Update the configuration for environment variable templating based on the current settings object
+	_configureEnvTemplating(pSettings)
+	{
+		// default environment variable templating to on
+		this._PerformEnvTemplating = !pSettings || pSettings.NoEnvReplacement !== true;
+	}
 
 	// Resolve (recursive) any environment variables found in settings object.
 	_resolveEnv(pSettings)
@@ -158,6 +164,8 @@ class FableSettings
 		{
 			this._resolveEnv(tmpSettingsTo);
 		}
+		// update env tempating config, since we just updated the config object, and it may have changed
+		this._configureEnvTemplating(tmpSettingsTo);
 
 		return tmpSettingsTo;
 	}

--- a/test/DisableEnvReplacement.json
+++ b/test/DisableEnvReplacement.json
@@ -1,0 +1,3 @@
+{
+	"NoEnvReplacement": true
+}

--- a/test/Fable-Settings_tests.js
+++ b/test/Fable-Settings_tests.js
@@ -266,6 +266,42 @@ suite
 						});
 					}
 				);
+				test
+				(
+					'updates environment variable replacement config after merging',
+					function()
+					{
+						process.env['NOT_DEFAULT'] = 'found_value';
+
+						const tmpFableSettings = require('../source/Fable-Settings.js').new(
+						{
+							EnvReplaced: '${NOT_DEFAULT|waffle}',
+							DefaultConfigFile: `${__dirname}/DisableEnvReplacement.json`,
+							ConfigFile: `${__dirname}/ExampleSettings.json`
+						});
+						Expect(tmpFableSettings).to.have.a.property('settings')
+							.that.is.a('object');
+						Expect(tmpFableSettings.settings).to.have.a.property('EnvReplaced')
+							.that.is.a('string');
+						Expect(tmpFableSettings.settings.EnvReplaced)
+							.to.equal('found_value');
+						Expect(tmpFableSettings.settings).to.have.a.property('Environment')
+							.that.is.a('string');
+						Expect(tmpFableSettings.settings.Environment)
+							.to.equal('${NOT_DEFAULT|default}-${USE_DEFAULT|default}');
+						Expect(tmpFableSettings.settings).to.have.a.property('EnvArray')
+							.that.is.an('array');
+						Expect(tmpFableSettings.settings.EnvArray)
+							.to.deep.equal(['${NOT_DEFAULT|default}', '${USE_DEFAULT|default}']);
+						Expect(tmpFableSettings.settings).to.have.a.property('ComplexMerge')
+							.that.is.an('object');
+						Expect(tmpFableSettings.settings.ComplexMerge).to.deep.equal(
+						{
+							OverriddenKey: 'ImportantValue',
+							NewKey: 'NewValue',
+						});
+					}
+				);
 			}
 		);
 	}


### PR DESCRIPTION
I ran into an issue where env replacements in my initial payload were not respected - only replacements in content loaded from files. This allows any step to use this feature, and it allows loading of config files (merging) to change the setting for future merges.