### PR TITLE
Change default fallback when injecting environment variables, for backward compatibility. Add test for this case.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fable-settings",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "description": "A simple, tolerant configuration chain.",
   "main": "source/Fable-Settings.js",
   "scripts": {

--- a/source/Fable-Settings-TemplateProcessor.js
+++ b/source/Fable-Settings-TemplateProcessor.js
@@ -24,8 +24,7 @@ class FableSettingsTemplateProcessor
 
 				let tmpSeparatorIndex = tmpTemplateValue.indexOf('|');
 
-				// If there is no pipe, the default value will end up being whatever the variable name is.
-				let tmpDefaultValue = tmpTemplateValue.substring(tmpSeparatorIndex+1);
+				const tmpDefaultValue = tmpSeparatorIndex >= 0 ? tmpTemplateValue.substring(tmpSeparatorIndex+1) : '';
 
 				let tmpEnvironmentVariableName = (tmpSeparatorIndex > -1) ? tmpTemplateValue.substring(0, tmpSeparatorIndex) : tmpTemplateValue;
 

--- a/test/ExampleSettings.json
+++ b/test/ExampleSettings.json
@@ -16,6 +16,7 @@
 	"MongoDBURL":"mongodb://127.0.0.1/Fable",
 
 	"Environment": "${NOT_DEFAULT|default}-${USE_DEFAULT|default}",
+	"EnvironmentNoDefault": "${NOT_DEFAULT}-${USE_DEFAULT}",
 
 	"EnvArray": [ "${NOT_DEFAULT|default}", "${USE_DEFAULT|default}" ],
 

--- a/test/Fable-Settings_tests.js
+++ b/test/Fable-Settings_tests.js
@@ -240,6 +240,10 @@ suite
 							.that.is.a('string');
 						Expect(tmpFableSettings.settings.Environment)
 							.to.equal('found_value-default');
+						Expect(tmpFableSettings.settings).to.have.a.property('EnvironmentNoDefault')
+							.that.is.a('string');
+						Expect(tmpFableSettings.settings.EnvironmentNoDefault)
+							.to.equal('found_value-');
 						Expect(tmpFableSettings.settings).to.have.a.property('EnvArray')
 							.that.is.an('array');
 						Expect(tmpFableSettings.settings.EnvArray)
@@ -273,6 +277,10 @@ suite
 							.that.is.a('string');
 						Expect(tmpFableSettings.settings.Environment)
 							.to.equal('${NOT_DEFAULT|default}-${USE_DEFAULT|default}');
+						Expect(tmpFableSettings.settings).to.have.a.property('EnvironmentNoDefault')
+							.that.is.a('string');
+						Expect(tmpFableSettings.settings.EnvironmentNoDefault)
+							.to.equal('${NOT_DEFAULT}-${USE_DEFAULT}');
 						Expect(tmpFableSettings.settings).to.have.a.property('EnvArray')
 							.that.is.an('array');
 						Expect(tmpFableSettings.settings.EnvArray)


### PR DESCRIPTION
## Changes

* Change default fallback when injecting environment variables, for backward compatibility. Add test for this case.
* Bump to 3.0.7. (separate commit)

## Testing Done

* Ran tests without change; they fail:

```sh
  12 passing (14ms)
  1 failing

  1) Fable-Settings
       Customization and twiddling of settings
         resolve environment variables:

      AssertionError: expected 'found_value-USE_DEFAULT' to equal 'found_value-'
      + expected - actual

      -found_value-USE_DEFAULT
      +found_value-

      at Context.<anonymous> (test/Fable-Settings_tests.js:246:12)
      at processImmediate (node:internal/timers:466:21)
```

* Ran tests with change; they pass:

```sh
bigal@bigal-hl-linux:/Pavia/fable-settings-bigal (master$=) % npm run test

> fable-settings@3.0.7 test
> ./node_modules/.bin/mocha -u tdd -R spec



  Fable-Settings
    Object Sanity
      ✔ initialize should build a happy little object
      ✔ legacy initialize should build a happy little object
      ✔ basic class parameters
    Customization and twiddling of settings
      ✔ passing in a value
      ✔ deep merging with a bad object passed in
      ✔ manually defining a settings object
      ✔ loading settings from a DEFAULT file
Fable-Settings Warning: Default configuration file specified but there was a problem loading it.  Falling back to base.
     Loading Exception: Error: Cannot find module '/Pavia/fable-settings-bigal/test/NO_SETTINGS_HERE.json'
Require stack:
- /Pavia/fable-settings-bigal/source/Fable-Settings.js
- /Pavia/fable-settings-bigal/test/Fable-Settings_tests.js
      ✔ loading settings from a nonexistant DEFAULT file
      ✔ loading settings from a file
Fable-Settings Warning: Configuration file specified but there was a problem loading it.  Falling back to base.
     Loading Exception: Error: Cannot find module '/Pavia/fable-settings-bigal/test/NO_SETTINGS_HERE.json'
Require stack:
- /Pavia/fable-settings-bigal/source/Fable-Settings.js
- /Pavia/fable-settings-bigal/test/Fable-Settings_tests.js
      ✔ loading settings from a nonexistant file
      ✔ resolve environment variables
      ✔ ignores environment variables if disabled
      ✔ updates environment variable replacement config after merging


  13 passing (18ms)
```